### PR TITLE
add method to project path onto constraint manifold, move some CBiRRT…

### DIFF
--- a/include/ompl/base/ConstrainedSpaceInformation.h
+++ b/include/ompl/base/ConstrainedSpaceInformation.h
@@ -39,9 +39,15 @@
 
 #include "ompl/base/SpaceInformation.h"
 #include "ompl/base/ConstraintInformation.h"
+#include "ompl/base/PlannerTerminationCondition.h"
 
 namespace ompl
 {
+    namespace geometric
+    {
+        class PathGeometric;
+    }
+
     namespace base
     {
         /// @cond IGNORE
@@ -63,8 +69,21 @@ namespace ompl
 
             const ConstraintInformationPtr& getConstraintInformation() const;
 
+            /// \brief Starting at a, interpolate toward b along the constraint manifold.
+            /// Store the resulting states in result.
+            bool constrainedExtend(const State *a, const State *b,
+                                   std::vector<State*>& result) const;
+
+            bool shortcutPath(geometric::PathGeometric *path, const PlannerTerminationCondition &ptc) const;
+
+            bool projectPath(const geometric::PathGeometric &inpath, geometric::PathGeometric &outpath,
+                bool waypointsValid = true) const;
+
         protected:
             ConstraintInformationPtr ci_;
+
+            /** \brief The random number generator used by shortcutPath */
+            mutable RNG rng_;
         };
 
     }

--- a/include/ompl/geometric/planners/rrt/CBiRRT2.h
+++ b/include/ompl/geometric/planners/rrt/CBiRRT2.h
@@ -156,13 +156,6 @@ namespace ompl
             /** \brief Grow a tree from nearMotion towards randMotion */
             GrowState growTree(TreeData &tree, TreeGrowingInfo &tgi, const Motion *randMotion, const Motion *nearMotion);
 
-            /// \brief Starting at a, interpolate toward b along the constraint manifold.
-            /// Store the resulting states in result.
-            bool constrainedExtend(const base::State* a, const base::State* b,
-                                   std::vector<base::State*>& result) const;
-
-            bool shortcutPath(PathGeometric *path, const base::PlannerTerminationCondition &ptc);
-
             /** \brief State sampler */
             base::StateSamplerPtr                          sampler_;
 
@@ -181,6 +174,8 @@ namespace ompl
             /** \brief The pair of states in each tree connected during planning.  Used for PlannerData computation */
             std::pair<base::State*, base::State*>          connectionPoint_;
 
+            /// \brief A pointer to the constraint space information
+            base::ConstrainedSpaceInformation*             csi_;
             /// \brief A pointer to the constraint information object that this planner uses
             base::ConstraintInformationPtr                 ci_;
         };

--- a/src/ConstrainedSpaceInformation.cpp
+++ b/src/ConstrainedSpaceInformation.cpp
@@ -35,6 +35,7 @@
 /* Author: Ryan Luna */
 
 #include "ompl/base/ConstrainedSpaceInformation.h"
+#include "ompl/geometric/PathGeometric.h"
 
 ompl::base::ConstrainedSpaceInformation::ConstrainedSpaceInformation(const StateSpacePtr &space)
     : ompl::base::SpaceInformation(space)
@@ -49,4 +50,181 @@ void ompl::base::ConstrainedSpaceInformation::setConstraintInformation(const Con
 const ompl::base::ConstraintInformationPtr& ompl::base::ConstrainedSpaceInformation::getConstraintInformation() const
 {
     return ci_;
+}
+
+bool ompl::base::ConstrainedSpaceInformation::constrainedExtend(const base::State *a, const base::State *b,
+                                                 std::vector<base::State*>& result) const
+{
+    // A semi-faithful implementation from the paper
+    // Instead of using vector operations, this implementation
+    // will accomplish a similar extension using interpolation in
+    // the state space
+
+    // Assuming a and b are both valid and on constraint manifold
+    base::StateSpacePtr ss = getStateSpace();
+    const base::State* previous = a;
+
+    // number of discrete steps between a and b in the state space
+    int n = ss->validSegmentCount(a, b);
+
+    if (n == 0) // don't divide by zero
+        return true;
+
+    double dist = distance(a, b);
+    double delta = dist / n; // This is the step size that we will take during extension
+
+    while (true)
+    {
+        // The distance to travel is less than our step size.  Just declare victory
+        if (dist < (delta + std::numeric_limits<double>::epsilon()))
+        {
+            result.push_back(cloneState(b));
+            return true;
+        }
+
+        // Compute the parametrization for interpolation
+        double t = delta / dist;
+
+        base::State* scratchState = allocState();
+        ss->interpolate(previous, b, t, scratchState);
+
+        // Project new state onto constraint manifold.  Make sure the new state is valid
+        // and that it has not deviated too far from where we started
+        if (!ci_->project(scratchState) ||
+            !isValid(scratchState) ||
+            distance(previous, scratchState) > 2.0*delta)
+        {
+            freeState(scratchState);
+            break;
+        }
+
+        // Check for divergence.  Divergence is declared if we are no closer to b
+        // than before projection
+        double newDist = distance(scratchState, b);
+        if (newDist >= dist)
+        {
+            // Since we already collision checked this state, we might as well keep it
+            result.push_back(scratchState);
+            break;
+        }
+        dist = newDist;
+
+        // No divergence; getting closer.  Store the new state
+        result.push_back(scratchState);
+        previous = scratchState;
+    }
+    return false;
+}
+bool ompl::base::ConstrainedSpaceInformation::shortcutPath(ompl::geometric::PathGeometric *path,
+	const base::PlannerTerminationCondition &ptc) const
+{
+    std::vector<base::State*>& states = path->getStates();
+
+    unsigned int count = 0;
+    unsigned int maxCount = 10;
+
+    while(!ptc && count < maxCount && states.size() > 3)
+    {
+        int i = rng_.uniformInt(0, states.size()-2);
+        int j;
+        do
+        {
+            j = rng_.uniformInt(0, states.size()-1);
+        } while (abs(i-j) < 2); // make sure the difference between i and j is at least two
+
+        if (i > j)
+            std::swap(i, j);
+
+        base::State* a = states[i];
+        base::State* b = states[j];
+        std::vector<base::State*> shortcut;
+
+        bool foundShortcut = false;
+        if (constrainedExtend(a, b, shortcut) && shortcut.size() > 1)
+        {
+            // see if shortcut is actually shorter
+            double shortcutDist = 0.0;
+            for(size_t k = 1; k < shortcut.size(); ++k)
+                shortcutDist += distance(shortcut[k-1], shortcut[k]);
+
+            double pathDist = 0.0;
+            for(int k = i+1; k < j; ++k)
+                pathDist += distance(states[k-1], states[k]);
+
+            if (shortcutDist < pathDist)
+            {
+                // Delete states between [i+1, j]
+                for(int k = i+1; k < j+1; ++k)
+                    freeState(states[k]);
+                states.erase(states.begin() + i+1, states.begin() + j+1);
+
+                // Inserting new shortcut
+                states.insert(states.begin() + i+1, shortcut.begin(), shortcut.end());
+                foundShortcut = true;
+            }
+        }
+
+        if (!foundShortcut)
+        {
+            for(size_t k = 0; k < shortcut.size(); ++k)
+                freeState(shortcut[k]);
+            count++;
+        }
+        else
+            count = 0;
+    }
+
+    return true;
+}
+
+bool ompl::base::ConstrainedSpaceInformation::projectPath(
+	const geometric::PathGeometric &inpath, geometric::PathGeometric &outpath,
+	bool waypointsValid) const
+{
+	unsigned int numStates = inpath.getStateCount();
+	bool result = true;
+	std::vector<State*> projectedWaypoints;
+
+	if (!waypointsValid)
+	{
+		base::State* scratchState = allocState();
+		for (unsigned int i = 0; i < numStates; ++i)
+		{
+			copyState(scratchState, inpath.getState(i));
+			if (!ci_->project(scratchState) || !isValid(scratchState))
+			{
+				freeState(scratchState);
+				for (unsigned int j = 0; j < projectedWaypoints.size(); ++j)
+					freeState(projectedWaypoints[j]);
+				return false;
+			}
+			projectedWaypoints.push_back(cloneState(scratchState));
+		}
+		freeState(scratchState);
+	}
+
+	const std::vector<State*>& instates = waypointsValid
+		? const_cast<geometric::PathGeometric&>(inpath).getStates()
+		: projectedWaypoints;
+	unsigned int numSegments = numStates - 1;
+	for (unsigned int i = 0; i < numSegments; ++i)
+	{
+		outpath.append(cloneState(instates[i]));
+		if (!constrainedExtend(instates[i], instates[i + 1], outpath.getStates()))
+		{
+			result = false;
+			break;
+		}
+	}
+	if (result)
+		outpath.append(cloneState(instates[numSegments]));
+	else
+	{
+		for (unsigned int i = 0; i < projectedWaypoints.size(); ++i)
+			freeState(projectedWaypoints[i]);
+		for (unsigned int i = 0; i < outpath.getStateCount(); ++i)
+			freeState(outpath.getState(i));
+	}
+
+	return result;
 }


### PR DESCRIPTION
…2 code to ConstrainedSpaceInformation class.

I tried to modify XXL.cpp like so:

```
-    pdef_->addSolutionPath(base::PathPtr(path), false, 0.0, getName());
+
+    base::ConstrainedSpaceInformation *csi = dynamic_cast<base::ConstrainedSpaceInformation*>(si_.get());
+    if (csi)
+    {
+        OMPL_INFORM("*** projecting path onto constraint manifold ***");
+        PathGeometric *cpath = new PathGeometric(si_);
+        csi->projectPath(*path, *cpath);
+        delete path;
+        pdef_->addSolutionPath(base::PathPtr(cpath), false, 0.0, getName());
+    }
+    else
+    {
+        OMPL_ERROR("*** wrong space information! *** ");
+    }
```

but that doesn't seem to work (the si_ is not ConstraintSpaceInformation*).
